### PR TITLE
Allow 'entry' to be an array in clients webpack config

### DIFF
--- a/plugin/WebpackCompiler.js
+++ b/plugin/WebpackCompiler.js
@@ -250,10 +250,10 @@ function prepareConfig(target, webpackConfig, usingDevServer) {
   }
 
   if (usingDevServer) {
-    webpackConfig.entry = [
+    webpackConfig.entry = [].concat(
       'webpack-hot-middleware/client?path=' + webpackConfig.devServer.protocol + '//' + webpackConfig.devServer.host + ':' + webpackConfig.devServer.port + '/__webpack_hmr',
       webpackConfig.entry
-    ];
+    );
   }
 
   if (!usingDevServer) {


### PR DESCRIPTION
This PR modifies the plugin to use array concat instead of building a new array and expecting webpackConfig.entry to be a string.
This allows multiple entries in client's webpack config.

For example adding [regenerator](https://github.com/facebook/regenerator) is easy now:
```js
entry: [
  'regenerator/runtime',
  './entry',
],
```
=> Ready for new es7 style async requests