### PR TITLE
Always use 'source-map' devTool for server

### DIFF
--- a/plugin/WebpackCompiler.js
+++ b/plugin/WebpackCompiler.js
@@ -236,7 +236,11 @@ function prepareConfig(target, webpackConfig, usingDevServer) {
   }
 
   if (IS_DEBUG) {
-    webpackConfig.devtool = webpackConfig.devtool || 'cheap-eval-module-source-map';
+    if (target === 'server') {
+      webpackConfig.devtool = webpackConfig.devtool || 'source-map';
+    } else {
+      webpackConfig.devtool = webpackConfig.devtool || 'cheap-eval-module-source-map';
+    }
 
     if (!webpackConfig.devServer) {
       webpackConfig.devServer = {};
@@ -254,18 +258,6 @@ function prepareConfig(target, webpackConfig, usingDevServer) {
       'webpack-hot-middleware/client?path=' + webpackConfig.devServer.protocol + '//' + webpackConfig.devServer.host + ':' + webpackConfig.devServer.port + '/__webpack_hmr',
       webpackConfig.entry
     ];
-  }
-
-  if (!usingDevServer) {
-    if (IS_DEBUG) {
-      if (target === 'server') {
-        webpackConfig.devtool = webpackConfig.devtool || 'cheap-module-source-map';
-      } else {
-        webpackConfig.devtool = webpackConfig.devtool || 'cheap-eval-module-source-map';
-      }
-    } else {
-      webpackConfig.devtool = webpackConfig.devtool || 'source-map';
-    }
   }
 
   webpackConfig.output.path = '/memory/webpack';


### PR DESCRIPTION
This PR changes the default devTool behavior:

DEBUG:
- server: `source-map`
- client: `cheap-eval-module-source-map`

NON-DEBUG:
- server & client: `source-map`

This should fix #18 

BTW: Do you think that it's a good idea to serve source maps in production by default? I would disable source-map emitting in production by default and allow the user somehow to enable it.
That's a problem with the current approach: There is no simple way of having a different webpack config for production - or am I wrong?