### PR TITLE
Consistant npm version

### DIFF
--- a/package.js
+++ b/package.js
@@ -22,7 +22,7 @@ Package.registerBuildPlugin({
       'underscore': '1.8.3',
       'connect': '3.4.0',
       'cors': '2.7.1',
-      'npm': '3.3.8',
+      'npm': '3.5.0',
       'webpack': '1.12.2',
       'webpack-dev-middleware': '1.2.0',
       'webpack-hot-middleware': '2.4.1',

--- a/plugin/WebpackCompiler.js
+++ b/plugin/WebpackCompiler.js
@@ -96,7 +96,7 @@ function runNpmInstall(target, files) {
           throw err;
         }
 
-        npm.commands.install(WEBPACK_NPM, ['npm@^3.3.8'], function(err) {
+        npm.commands.install(WEBPACK_NPM, ['npm@^3.5.0'], function(err) {
           if (err) {
             throw err;
           }


### PR DESCRIPTION
Recently we've had issues with slow builds and a ton of `npm WARN`'s being logged to the console on startup. After some digging in, I've noticed `npm` version being inconsistently configured, some areas referencing 3.3.8 and others 3.5.0. After changing to `3.5.0` across the board it _seems_ that we have a lot less `npm WARN`'s being logged, and perhaps a slightly faster build, but I'd count that unconfirmed. I'm opening this issue to see if there's a reason why `npm` version is inconsistent, and if there's merit to making it consistent across the board.