### PR TITLE
included sass-resource-loader

### DIFF
--- a/packages/sass/README.md
+++ b/packages/sass/README.md
@@ -1,7 +1,12 @@
 # webpack:sass by [The Reactive Stack](https://thereactivestack.com)
 Meteor package to integrate SASS (.scss) import with [Webpack](https://github.com/thereactivestack/meteor-webpack)
 
+It includes `sass-resources-loader`
+This loader will `@import` your SASS resources into every required SASS module. 
+So you can use your shared variables & mixins across all SASS styles without manually importing them in each file. Made to work with CSS Modules!
+
 ## Settings (webpack.json)
 - `css.module`: Enable local CSS by default
 - `sass`: Setting object with node-sass options
 - `sass.includePaths`: Set an array of includedPaths for the import
+- `sassResources`: Set an single or array of paths of shared varaibles & mixins.

--- a/packages/sass/webpack.config.js
+++ b/packages/sass/webpack.config.js
@@ -4,14 +4,24 @@ function dependencies(settings) {
   return {
     devDependencies: {
       'sass-loader': '^3.1.2',
-      'node-sass': '^3.4.2'
+      'node-sass': '^3.4.2',
+      "sass-resources-loader": "1.0.2"
     }
   };
 }
 
 function config(settings, require) {
   var plugins = [];
-  var cssLoader = settings.cssLoader + '!sass?' + JSON.stringify(settings.sass || {});
+  var cssLoader;
+  var config = settings.sassResources ? { "sassResources":settings.sassResources }  : {};
+
+  if(settings.sassResources){
+    cssLoader = settings.cssLoader + '!sass!sass-resources?' + JSON.stringify(settings.sass || {});
+    console.log(cssLoader);
+  }else {
+    cssLoader = settings.cssLoader + '!sass?' + JSON.stringify(settings.sass || {});
+    console.log(cssLoader);
+  }
 
   if (settings.cssExtract) {
     var ExtractTextPlugin = require('extract-text-webpack-plugin');
@@ -20,6 +30,7 @@ function config(settings, require) {
 
   return {
     loaders: [{ test: /\.scss$/, loader: cssLoader }],
-    extensions: ['.scss']
+    extensions: ['.scss'],
+    config:config
   };
 }

--- a/packages/sass/webpack.config.js
+++ b/packages/sass/webpack.config.js
@@ -17,10 +17,8 @@ function config(settings, require) {
 
   if(settings.sassResources){
     cssLoader = settings.cssLoader + '!sass!sass-resources?' + JSON.stringify(settings.sass || {});
-    console.log(cssLoader);
   }else {
     cssLoader = settings.cssLoader + '!sass?' + JSON.stringify(settings.sass || {});
-    console.log(cssLoader);
   }
 
   if (settings.cssExtract) {


### PR DESCRIPTION
Example usage:

webpack.json
--
```
{
  "sassResources": ["./node_modules/reactionic/src/ionic-scss/_variables.scss","./node_modules/reactionic/src/ionic-scss/_mixins.scss"]
}
```

Component importing specific sass file
-----
```
import classnames from 'classnames';
import 'reactionic/src/ionic-scss/_bar.scss';

var FooterBar = React.createClass({
    propTypes: {
        customClasses: React.PropTypes.string,
        hasTabs: React.PropTypes.bool
    },

    getDefaultProps: function () {
        return {
            customClasses: '',
            hasTabs: false
        };
    },

    render () {
        var classes = classnames(
            {'bar': true, 'bar-footer': true},
            this.props.customClasses || 'bar-stable',
            {'has-tabs': this.props.hasTabs}
        );
        return (
            <div className={ classes }>
                { this.props.children}
            </div>
        )
    }
});

export default FooterBar;
```