### PR TITLE
Allow setting devtool in webpack.json

### DIFF
--- a/packages/webpack/plugin/WebpackCompiler.js
+++ b/packages/webpack/plugin/WebpackCompiler.js
@@ -81,7 +81,8 @@ WebpackCompiler = class WebpackCompiler {
         extensions: ['']
       },
       externals: {},
-      devServer: settings.devServer
+      devServer: settings.devServer,
+      devtool: settings.devtool
     };
 
     if (settings.root) {


### PR DESCRIPTION
As source maps are an issue for many people (Some want better source maps but generating them by default would slow build down for everyone...) it would be nice to allow setting them in webpack.json

As you suggested this in #74 I assume this is missing by accident so I added it.
This should fix #74.