### PR TITLE
Add support to exclude folders from css-modules & styles sourceMap's

### DIFF
--- a/packages/css/webpack.config.js
+++ b/packages/css/webpack.config.js
@@ -15,7 +15,7 @@ function config(settings, require) {
   var loaders = [];
   var plugins = [];
 
-  var queries = settings.css || {};
+  var queries = _.clone(settings.css || {});
 
   // Support old setting
   if (queries.module) {
@@ -23,7 +23,15 @@ function config(settings, require) {
     delete queries.module;
   }
 
-  if (!queries.localIdentName) {
+  if (settings.styles && settings.styles.sourceMap) {
+    queries.sourceMap = true;
+  }
+
+  if (queries.modulesExcludes) {
+    delete queries.modulesExcludes;
+  }
+
+  if (queries.modules && !queries.localIdentName) {
     queries.localIdentName = '[name]__[local]__[hash:base64:5]';
   }
 
@@ -50,9 +58,21 @@ function config(settings, require) {
     cssLoader = ExtractTextPlugin.extract('style', cssLoader);
   }
 
+  var _mapRegex = function(stringArray) {
+    var result = [];
+    for (var i = 0, len = stringArray.length; i < len; i++) {
+      result.push(new RegExp(stringArray[i]));
+    }
+    return result;
+  };
+
   // Let postcss control CSS files if it is there
   if (cssLoader && settings.packages.indexOf('webpack:postcss') < 0) {
-    loaders.push({ test: /\.css$/, loader: cssLoader });
+    if (settings.css && settings.css.modules && settings.css.modulesExcludes) {
+      loaders.push({ test: /\.css$/, loader: cssLoader, exclude: _mapRegex(settings.css.modulesExcludes) });
+    } else {
+      loaders.push({ test: /\.css$/, loader: cssLoader });
+    }
   }
 
   return {

--- a/packages/css/webpack.config.js
+++ b/packages/css/webpack.config.js
@@ -23,7 +23,7 @@ function config(settings, require) {
     delete queries.module;
   }
 
-  if (settings.styles && settings.styles.sourceMap) {
+  if (process.env.NODE_ENV !== 'production' && settings.styles && settings.styles.sourceMap) {
     queries.sourceMap = true;
   }
 

--- a/packages/less/webpack.config.js
+++ b/packages/less/webpack.config.js
@@ -12,13 +12,37 @@ function dependencies(settings) {
 function config(settings, require) {
   var cssLoader = settings.cssLoader + '!less';
 
+  if (settings.styles && settings.styles.sourceMap) {
+    cssLoader += '?sourceMap';
+  }
+
+  // a loader without css-modules, used in case the settings have "modulesExcludes"
+  var simpleCssLoader = 'style-loader!css-loader';
+
   if (settings.cssExtract) {
     var ExtractTextPlugin = require('extract-text-webpack-plugin');
     cssLoader = ExtractTextPlugin.extract('style', cssLoader);
   }
+  
+  var finalLoaders = [];
+  var _mapRegex = function(stringArray) {
+    var result = [];
+    for (var i = 0, len = stringArray.length; i < len; i++) {
+      result.push(new RegExp(stringArray[i]));
+    }
+    return result;
+  };
+
+  if (settings.css && settings.css.modules && settings.css.modulesExcludes) {
+    finalLoaders.push({ test: /\.less$/, loader: cssLoader, exclude: _mapRegex(settings.css.modulesExcludes) });
+    // add a simple css loader too with the same "include" option as the normal case will be to import final-compiled dist-files (which are .css)
+    finalLoaders.push({ test: /\.css$/, loader: simpleCssLoader, include: _mapRegex(settings.css.modulesExcludes) });
+  } else {
+    finalLoaders.push({ test: /\.less$/, loader: cssLoader });
+  }
 
   return {
-    loaders: [{ test: /\.less$/, loader: cssLoader }],
+    loaders: finalLoaders,
     extensions: ['.less']
   };
 }

--- a/packages/less/webpack.config.js
+++ b/packages/less/webpack.config.js
@@ -12,7 +12,7 @@ function dependencies(settings) {
 function config(settings, require) {
   var cssLoader = settings.cssLoader + '!less';
 
-  if (settings.styles && settings.styles.sourceMap) {
+  if (process.env.NODE_ENV !== 'production' && settings.styles && settings.styles.sourceMap) {
     cssLoader += '?sourceMap';
   }
 
@@ -22,6 +22,7 @@ function config(settings, require) {
   if (settings.cssExtract) {
     var ExtractTextPlugin = require('extract-text-webpack-plugin');
     cssLoader = ExtractTextPlugin.extract('style', cssLoader);
+    simpleCssLoader = ExtractTextPlugin.extract('style', simpleCssLoader);
   }
   
   var finalLoaders = [];

--- a/packages/postcss/webpack.config.js
+++ b/packages/postcss/webpack.config.js
@@ -38,6 +38,10 @@ function config(settings, require) {
   // Add postcss support to LESS, SASS, stylus, ...
   settings.cssLoader += '!postcss';
 
+  if (settings.styles && settings.styles.sourceMap) {
+    settings.cssLoader += '?sourceMap';
+  }
+
   var cssLoader = settings.cssLoader;
 
   if (settings.cssExtract) {
@@ -45,8 +49,20 @@ function config(settings, require) {
     cssLoader = ExtractTextPlugin.extract('style', cssLoader);
   }
 
+  var _mapRegex = function(stringArray) {
+    var result = [];
+    for (var i = 0, len = stringArray.length; i < len; i++) {
+      result.push(new RegExp(stringArray[i]));
+    }
+    return result;
+  };
+
   if (cssLoader) {
-    loaders.push({ test: /\.css$/, loader: cssLoader });
+    if (settings.css && settings.css.modules && settings.css.modulesExcludes) {
+      loaders.push({ test: /\.css$/, loader: cssLoader, exclude: _mapRegex(settings.css.modulesExcludes) });
+    } else {
+      loaders.push({ test: /\.css$/, loader: cssLoader });
+    }
   }
 
   return {

--- a/packages/postcss/webpack.config.js
+++ b/packages/postcss/webpack.config.js
@@ -38,7 +38,7 @@ function config(settings, require) {
   // Add postcss support to LESS, SASS, stylus, ...
   settings.cssLoader += '!postcss';
 
-  if (settings.styles && settings.styles.sourceMap) {
+  if (process.env.NODE_ENV !== 'production' && settings.styles && settings.styles.sourceMap) {
     settings.cssLoader += '?sourceMap';
   }
 

--- a/packages/sass/webpack.config.js
+++ b/packages/sass/webpack.config.js
@@ -20,9 +20,12 @@ function config(settings, require) {
   var config = {};
 
   // a loader without css-modules, used in case the settings have "modulesExcludes"
-  var simpleCssLoader = 'style-loader!css-loader';
+  var simpleCssLoader = 'css?{}';
+  if (settings.packages.indexOf('webpack:postcss') > 0) {
+    simpleCssLoader += '!postcss';
+  }
 
-  if (settings.styles && settings.styles.sourceMap) {
+  if (process.env.NODE_ENV !== 'production' && settings.styles && settings.styles.sourceMap) {
     if (!settings.sass) {
       settings.sass = {};
     }
@@ -47,6 +50,7 @@ function config(settings, require) {
   if (settings.cssExtract) {
     var ExtractTextPlugin = require('extract-text-webpack-plugin');
     cssLoader = ExtractTextPlugin.extract('style', cssLoader);
+    simpleCssLoader = ExtractTextPlugin.extract('style', 'css-loader');
   }
 
   var finalLoaders = [];

--- a/packages/sass/webpack.config.js
+++ b/packages/sass/webpack.config.js
@@ -20,7 +20,7 @@ function config(settings, require) {
   var config = {};
 
   // a loader without css-modules, used in case the settings have "modulesExcludes"
-  var simpleCssLoader = 'css?{}';
+  var simpleCssLoader = process.env.NODE_ENV !== 'production' ? 'style-loader!css-loader' : 'css?{}';
   if (settings.packages.indexOf('webpack:postcss') > 0) {
     simpleCssLoader += '!postcss';
   }

--- a/packages/sass/webpack.config.js
+++ b/packages/sass/webpack.config.js
@@ -18,15 +18,29 @@ function dependencies(settings) {
 function config(settings, require) {
   var plugins = [];
   var config = {};
-  var cssLoader = settings.cssLoader + '!sass?' + JSON.stringify(settings.sass || {});
+
+  // a loader without css-modules, used in case the settings have "modulesExcludes"
+  var simpleCssLoader = 'style-loader!css-loader';
+
+  if (settings.styles && settings.styles.sourceMap) {
+    if (!settings.sass) {
+      settings.sass = {};
+    }
+    settings.sass.sourceMap = true;
+  }
+
+  var sassLoader = '!sass?' + JSON.stringify(settings.sass || {});
+  var cssLoader = settings.cssLoader + sassLoader;
 
   // Clone and add indentedSyntax param
-  var indentedLoader = JSON.parse(JSON.stringify(settings.sass || {}));
-  indentedLoader.indentedSyntax = true;
-  indentedLoader = settings.cssLoader + '!sass?' + JSON.stringify(indentedLoader);
+  var indentedLoaderOpts = JSON.parse(JSON.stringify(settings.sass || {}));
+  indentedLoaderOpts.indentedSyntax = true;
+  var indentedLoader = settings.cssLoader + '!sass?' + JSON.stringify(indentedLoaderOpts);
+  var indentedSassLoader = simpleCssLoader + '!sass?' + JSON.stringify(indentedLoaderOpts);
 
   if (settings.sassResources) {
     config.sassResources = settings.sassResources;
+    sassLoader += '!sass-resources';
     cssLoader += '!sass-resources';
   }
 
@@ -35,11 +49,31 @@ function config(settings, require) {
     cssLoader = ExtractTextPlugin.extract('style', cssLoader);
   }
 
+  var finalLoaders = [];
+  var _mapRegex = function(stringArray) {
+    var result = [];
+    for (var i = 0, len = stringArray.length; i < len; i++) {
+      result.push(new RegExp(stringArray[i]));
+    }
+    return result;
+  };
+
+  if (settings.css && settings.css.modules && settings.css.modulesExcludes) {
+    // include the normal loaders with activated css-modules with an "exclude" regex-array (so we can exclude imports from ~/nodes_modules/)
+    finalLoaders.push({ test: /\.scss$/, loader: cssLoader, exclude: _mapRegex(settings.css.modulesExcludes) });
+    finalLoaders.push({ test: /\.sass$/, loader: indentedLoader, exclude: _mapRegex(settings.css.modulesExcludes) });
+    // include additional rules for the same file types with an explicit "include" option for the same folders
+    finalLoaders.push({ test: /\.scss$/, loader: simpleCssLoader + sassLoader, include: _mapRegex(settings.css.modulesExcludes) });
+    finalLoaders.push({ test: /\.sass/, loader: indentedSassLoader, include: _mapRegex(settings.css.modulesExcludes) });
+    // add a simple css loader too with the same "include" option as the normal case will be to import final-compiled dist-files (which are .css)
+    finalLoaders.push({ test: /\.css$/, loader: simpleCssLoader, include: _mapRegex(settings.css.modulesExcludes) });
+  } else {
+    finalLoaders.push({ test: /\.scss$/, loader: cssLoader });
+    finalLoaders.push({ test: /\.sass$/, loader: indentedLoader });
+  }
+
   return {
-    loaders: [
-      { test: /\.scss$/, loader: cssLoader },
-      { test: /\.sass$/, loader: indentedLoader }
-    ],
+    loaders: finalLoaders,
     extensions: ['.scss', '.sass'],
     config: config
   };

--- a/packages/webpack/.npm/plugin/webpack:webpack/npm-shrinkwrap.json
+++ b/packages/webpack/.npm/plugin/webpack:webpack/npm-shrinkwrap.json
@@ -3,124 +3,124 @@
     "connect": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz",
-      "from": "connect@3.4.1",
+      "from": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz",
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "from": "debug@>=2.2.0 <2.3.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "from": "ms@0.7.1"
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "finalhandler": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
-          "from": "finalhandler@0.4.1",
+          "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
           "dependencies": {
             "escape-html": {
               "version": "1.0.3",
               "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-              "from": "escape-html@>=1.0.3 <1.1.0"
+              "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
             },
             "on-finished": {
               "version": "2.3.0",
               "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-              "from": "on-finished@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "dependencies": {
                 "ee-first": {
                   "version": "1.1.1",
                   "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-                  "from": "ee-first@1.1.1"
+                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                 }
               }
             },
             "unpipe": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-              "from": "unpipe@>=1.0.0 <1.1.0"
+              "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
         },
         "parseurl": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-          "from": "parseurl@>=1.3.1 <1.4.0"
+          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
         },
         "utils-merge": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-          "from": "utils-merge@1.0.0"
+          "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         }
       }
     },
     "cors": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz",
-      "from": "cors@2.7.1",
+      "from": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz",
       "dependencies": {
         "vary": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
-          "from": "vary@>=1.0.0 <2.0.0"
+          "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
         }
       }
     },
     "memory-fs": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
-      "from": "memory-fs@0.3.0",
+      "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
       "dependencies": {
         "errno": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-          "from": "errno@>=0.1.3 <0.2.0",
+          "from": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
           "dependencies": {
             "prr": {
               "version": "0.0.0",
               "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-              "from": "prr@>=0.0.0 <0.1.0"
+              "from": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
             }
           }
         },
         "readable-stream": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
-          "from": "readable-stream@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "from": "core-util-is@>=1.0.0 <1.1.0"
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "inherits": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "from": "inherits@>=2.0.1 <2.1.0"
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "isarray": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "from": "isarray@>=1.0.0 <1.1.0"
+              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             },
             "process-nextick-args": {
               "version": "1.0.7",
               "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-              "from": "process-nextick-args@>=1.0.6 <1.1.0"
+              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "from": "string_decoder@>=0.10.0 <0.11.0"
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "util-deprecate": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "from": "util-deprecate@>=1.0.1 <1.1.0"
+              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             }
           }
         }
@@ -129,377 +129,321 @@
     "mime": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "from": "mime@1.3.4"
+      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
     },
     "underscore": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "from": "underscore@1.8.3"
+      "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
     "webpack": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.13.0.tgz",
-      "from": "webpack@1.13.0",
+      "from": "https://registry.npmjs.org/webpack/-/webpack-1.13.0.tgz",
       "dependencies": {
         "acorn": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.1.0.tgz",
-          "from": "acorn@>=3.0.0 <4.0.0"
+          "from": "https://registry.npmjs.org/acorn/-/acorn-3.1.0.tgz"
         },
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "from": "async@>=1.3.0 <2.0.0"
+          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "clone": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-          "from": "clone@>=1.0.2 <2.0.0"
+          "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
         },
         "enhanced-resolve": {
           "version": "0.9.1",
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
-          "from": "enhanced-resolve@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "4.1.4",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-              "from": "graceful-fs@>=4.1.2 <5.0.0"
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
             },
             "memory-fs": {
               "version": "0.2.0",
               "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
-              "from": "memory-fs@>=0.2.0 <0.3.0"
+              "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
             }
           }
         },
         "interpret": {
           "version": "0.6.6",
           "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
-          "from": "interpret@>=0.6.4 <0.7.0"
+          "from": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
         },
         "loader-utils": {
           "version": "0.2.14",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
-          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-              "from": "big.js@>=3.1.3 <4.0.0"
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.2.tgz",
-              "from": "emojis-list@>=1.0.0 <2.0.0"
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.2.tgz"
             },
             "json5": {
               "version": "0.5.0",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
-              "from": "json5@>=0.5.0 <0.6.0"
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             },
             "object-assign": {
               "version": "4.1.0",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-              "from": "object-assign@>=4.0.1 <5.0.0"
-            }
-          }
-        },
-        "memory-fs": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
-          "from": "memory-fs@>=0.3.0 <0.4.0",
-          "dependencies": {
-            "errno": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-              "from": "errno@>=0.1.3 <0.2.0",
-              "dependencies": {
-                "prr": {
-                  "version": "0.0.0",
-                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-                  "from": "prr@>=0.0.0 <0.1.0"
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
-              "from": "readable-stream@>=2.0.1 <3.0.0",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "from": "inherits@>=2.0.1 <2.1.0"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "from": "isarray@>=1.0.0 <1.1.0"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "from": "string_decoder@>=0.10.0 <0.11.0"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0"
-                }
-              }
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "from": "minimist@0.0.8"
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "node-libs-browser": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
-          "from": "node-libs-browser@>=0.4.0 <=0.6.0",
+          "from": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
           "dependencies": {
             "assert": {
               "version": "1.3.0",
               "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
-              "from": "assert@>=1.1.1 <2.0.0"
+              "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
             },
             "browserify-zlib": {
               "version": "0.1.4",
               "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-              "from": "browserify-zlib@>=0.1.4 <0.2.0",
+              "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
               "dependencies": {
                 "pako": {
                   "version": "0.2.8",
                   "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz",
-                  "from": "pako@>=0.2.0 <0.3.0"
+                  "from": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
                 }
               }
             },
             "buffer": {
               "version": "3.6.0",
               "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
-              "from": "buffer@>=3.0.3 <4.0.0",
+              "from": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
               "dependencies": {
                 "base64-js": {
                   "version": "0.0.8",
                   "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-                  "from": "base64-js@0.0.8"
+                  "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
                 },
                 "ieee754": {
                   "version": "1.1.6",
                   "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
-                  "from": "ieee754@>=1.1.4 <2.0.0"
+                  "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "from": "isarray@>=1.0.0 <2.0.0"
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 }
               }
             },
             "console-browserify": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-              "from": "console-browserify@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-                  "from": "date-now@>=0.1.4 <0.2.0"
+                  "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "constants-browserify": {
               "version": "0.0.1",
               "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
-              "from": "constants-browserify@0.0.1"
+              "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
             },
             "crypto-browserify": {
               "version": "3.2.8",
               "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
-              "from": "crypto-browserify@>=3.2.6 <3.3.0",
+              "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
               "dependencies": {
                 "pbkdf2-compat": {
                   "version": "2.0.1",
                   "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
-                  "from": "pbkdf2-compat@2.0.1"
+                  "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
                 },
                 "ripemd160": {
                   "version": "0.2.0",
                   "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
-                  "from": "ripemd160@0.2.0"
+                  "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
                 },
                 "sha.js": {
                   "version": "2.2.6",
                   "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
-                  "from": "sha.js@2.2.6"
+                  "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
                 }
               }
             },
             "domain-browser": {
               "version": "1.1.7",
               "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-              "from": "domain-browser@>=1.1.1 <2.0.0"
+              "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
             },
             "events": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz",
-              "from": "events@>=1.0.0 <2.0.0"
+              "from": "https://registry.npmjs.org/events/-/events-1.1.0.tgz"
             },
             "http-browserify": {
               "version": "1.7.0",
               "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
-              "from": "http-browserify@>=1.3.2 <2.0.0",
+              "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
               "dependencies": {
                 "Base64": {
                   "version": "0.2.1",
                   "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-                  "from": "Base64@>=0.2.0 <0.3.0"
+                  "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "from": "inherits@>=2.0.1 <2.1.0"
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "https-browserify": {
               "version": "0.0.0",
               "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
-              "from": "https-browserify@0.0.0"
+              "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
             },
             "os-browserify": {
               "version": "0.1.2",
               "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
-              "from": "os-browserify@>=0.1.2 <0.2.0"
+              "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
             },
             "path-browserify": {
               "version": "0.0.0",
               "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-              "from": "path-browserify@0.0.0"
+              "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
             },
             "process": {
               "version": "0.11.2",
               "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz",
-              "from": "process@>=0.11.0 <0.12.0"
+              "from": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
             },
             "punycode": {
               "version": "1.4.1",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-              "from": "punycode@>=1.2.4 <2.0.0"
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
             },
             "querystring-es3": {
               "version": "0.2.1",
               "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-              "from": "querystring-es3@>=0.2.0 <0.3.0"
+              "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
             },
             "readable-stream": {
               "version": "1.1.14",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-              "from": "readable-stream@>=1.1.13 <2.0.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "from": "inherits@>=2.0.1 <2.1.0"
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "from": "isarray@0.0.1"
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 }
               }
             },
             "stream-browserify": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-              "from": "stream-browserify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "from": "inherits@>=2.0.1 <2.1.0"
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "string_decoder": {
               "version": "0.10.31",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "from": "string_decoder@>=0.10.25 <0.11.0"
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "timers-browserify": {
               "version": "1.4.2",
               "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-              "from": "timers-browserify@>=1.0.1 <2.0.0"
+              "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
             },
             "tty-browserify": {
               "version": "0.0.0",
               "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-              "from": "tty-browserify@0.0.0"
+              "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
             },
             "url": {
               "version": "0.10.3",
               "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-              "from": "url@>=0.10.1 <0.11.0",
+              "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-                  "from": "punycode@1.3.2"
+                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                 },
                 "querystring": {
                   "version": "0.2.0",
                   "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-                  "from": "querystring@0.2.0"
+                  "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
                 }
               }
             },
             "util": {
               "version": "0.10.3",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-              "from": "util@>=0.10.3 <0.11.0",
+              "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "from": "inherits@2.0.1"
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "vm-browserify": {
               "version": "0.0.4",
               "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-              "from": "vm-browserify@0.0.4",
+              "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
               "dependencies": {
                 "indexof": {
                   "version": "0.0.1",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-                  "from": "indexof@0.0.1"
+                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
             }
@@ -508,144 +452,144 @@
         "optimist": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "from": "optimist@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.10",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-              "from": "minimist@>=0.0.1 <0.1.0"
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             },
             "wordwrap": {
               "version": "0.0.3",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "from": "wordwrap@>=0.0.2 <0.1.0"
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             }
           }
         },
         "supports-color": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "from": "supports-color@>=3.1.0 <4.0.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "dependencies": {
             "has-flag": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "from": "has-flag@>=1.0.0 <2.0.0"
+              "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
             }
           }
         },
         "tapable": {
           "version": "0.1.10",
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
-          "from": "tapable@>=0.1.8 <0.2.0"
+          "from": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
         },
         "uglify-js": {
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
-          "from": "uglify-js@>=2.6.0 <2.7.0",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-              "from": "async@>=0.2.6 <0.3.0"
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.5.6",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-              "from": "source-map@>=0.5.1 <0.6.0"
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0"
+              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
               "version": "3.10.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "from": "yargs@>=3.10.0 <3.11.0",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                  "from": "camelcase@>=1.0.2 <2.0.0"
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "cliui": {
                   "version": "2.1.0",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                  "from": "cliui@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.3",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "3.0.3",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
-                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.3",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0"
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                              "from": "longest@>=1.0.1 <2.0.0"
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.4",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                              "from": "repeat-string@>=1.5.2 <2.0.0"
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                             }
                           }
                         },
                         "lazy-cache": {
                           "version": "1.0.4",
                           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-                          "from": "lazy-cache@>=1.0.3 <2.0.0"
+                          "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                         }
                       }
                     },
                     "right-align": {
                       "version": "0.1.3",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "3.0.3",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
-                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.3",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0"
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                              "from": "longest@>=1.0.1 <2.0.0"
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.4",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                              "from": "repeat-string@>=1.5.2 <2.0.0"
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                             }
                           }
                         }
@@ -654,19 +598,19 @@
                     "wordwrap": {
                       "version": "0.0.2",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                      "from": "wordwrap@0.0.2"
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.2.0",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                  "from": "decamelize@>=1.0.0 <2.0.0"
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "window-size": {
                   "version": "0.1.0",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                  "from": "window-size@0.1.0"
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                 }
               }
             }
@@ -675,91 +619,91 @@
         "watchpack": {
           "version": "0.2.9",
           "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
-          "from": "watchpack@>=0.2.1 <0.3.0",
+          "from": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
           "dependencies": {
             "async": {
               "version": "0.9.2",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-              "from": "async@>=0.9.0 <0.10.0"
+              "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
             },
             "chokidar": {
               "version": "1.4.3",
               "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
-              "from": "chokidar@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
               "dependencies": {
                 "anymatch": {
                   "version": "1.3.0",
                   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-                  "from": "anymatch@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                   "dependencies": {
                     "arrify": {
                       "version": "1.0.1",
                       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                      "from": "arrify@>=1.0.0 <2.0.0"
+                      "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
                     },
                     "micromatch": {
                       "version": "2.3.8",
                       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz",
-                      "from": "micromatch@>=2.1.5 <3.0.0",
+                      "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz",
                       "dependencies": {
                         "arr-diff": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                          "from": "arr-diff@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                           "dependencies": {
                             "arr-flatten": {
                               "version": "1.0.1",
                               "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-                              "from": "arr-flatten@>=1.0.1 <2.0.0"
+                              "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
                             }
                           }
                         },
                         "array-unique": {
                           "version": "0.2.1",
                           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                          "from": "array-unique@>=0.2.1 <0.3.0"
+                          "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                         },
                         "braces": {
                           "version": "1.8.4",
                           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.4.tgz",
-                          "from": "braces@>=1.8.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/braces/-/braces-1.8.4.tgz",
                           "dependencies": {
                             "expand-range": {
                               "version": "1.8.2",
                               "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-                              "from": "expand-range@>=1.8.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
                               "dependencies": {
                                 "fill-range": {
                                   "version": "2.2.3",
                                   "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                                  "from": "fill-range@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                                   "dependencies": {
                                     "is-number": {
                                       "version": "2.1.0",
                                       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                                      "from": "is-number@>=2.1.0 <3.0.0"
+                                      "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
                                     },
                                     "isobject": {
                                       "version": "2.1.0",
                                       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                                      "from": "isobject@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                                       "dependencies": {
                                         "isarray": {
                                           "version": "1.0.0",
                                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                                          "from": "isarray@1.0.0"
+                                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                                         }
                                       }
                                     },
                                     "randomatic": {
                                       "version": "1.1.5",
                                       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-                                      "from": "randomatic@>=1.1.3 <2.0.0"
+                                      "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
                                       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                                      "from": "repeat-string@>=1.5.2 <2.0.0"
+                                      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                     }
                                   }
                                 }
@@ -768,114 +712,114 @@
                             "preserve": {
                               "version": "0.2.0",
                               "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                              "from": "preserve@>=0.2.0 <0.3.0"
+                              "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                             },
                             "repeat-element": {
                               "version": "1.1.2",
                               "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                              "from": "repeat-element@>=1.1.2 <2.0.0"
+                              "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                             }
                           }
                         },
                         "expand-brackets": {
                           "version": "0.1.5",
                           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                          "from": "expand-brackets@>=0.1.4 <0.2.0",
+                          "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                           "dependencies": {
                             "is-posix-bracket": {
                               "version": "0.1.1",
                               "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-                              "from": "is-posix-bracket@>=0.1.0 <0.2.0"
+                              "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
                             }
                           }
                         },
                         "extglob": {
                           "version": "0.3.2",
                           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                          "from": "extglob@>=0.3.1 <0.4.0"
+                          "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
                         },
                         "filename-regex": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-                          "from": "filename-regex@>=2.0.0 <3.0.0"
+                          "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                          "from": "is-extglob@>=1.0.0 <2.0.0"
+                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         },
                         "kind-of": {
                           "version": "3.0.3",
                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
-                          "from": "kind-of@>=3.0.2 <4.0.0",
+                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
                           "dependencies": {
                             "is-buffer": {
                               "version": "1.1.3",
                               "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
-                              "from": "is-buffer@>=1.0.2 <2.0.0"
+                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                             }
                           }
                         },
                         "normalize-path": {
                           "version": "2.0.1",
                           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-                          "from": "normalize-path@>=2.0.1 <3.0.0"
+                          "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                         },
                         "object.omit": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-                          "from": "object.omit@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                           "dependencies": {
                             "for-own": {
                               "version": "0.1.4",
                               "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-                              "from": "for-own@>=0.1.3 <0.2.0",
+                              "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
                               "dependencies": {
                                 "for-in": {
                                   "version": "0.1.5",
                                   "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz",
-                                  "from": "for-in@>=0.1.5 <0.2.0"
+                                  "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
                                 }
                               }
                             },
                             "is-extendable": {
                               "version": "0.1.1",
                               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-                              "from": "is-extendable@>=0.1.1 <0.2.0"
+                              "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
                             }
                           }
                         },
                         "parse-glob": {
                           "version": "3.0.4",
                           "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                          "from": "parse-glob@>=3.0.4 <4.0.0",
+                          "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                           "dependencies": {
                             "glob-base": {
                               "version": "0.3.0",
                               "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                              "from": "glob-base@>=0.3.0 <0.4.0"
+                              "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                             },
                             "is-dotfile": {
                               "version": "1.0.2",
                               "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-                              "from": "is-dotfile@>=1.0.0 <2.0.0"
+                              "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
                             }
                           }
                         },
                         "regex-cache": {
                           "version": "0.4.3",
                           "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-                          "from": "regex-cache@>=0.4.2 <0.5.0",
+                          "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                           "dependencies": {
                             "is-equal-shallow": {
                               "version": "0.1.3",
                               "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                              "from": "is-equal-shallow@>=0.1.3 <0.2.0"
+                              "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                             },
                             "is-primitive": {
                               "version": "2.0.0",
                               "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-                              "from": "is-primitive@>=2.0.0 <3.0.0"
+                              "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                             }
                           }
                         }
@@ -886,71 +830,71 @@
                 "async-each": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz",
-                  "from": "async-each@>=1.0.0 <2.0.0"
+                  "from": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz"
                 },
                 "glob-parent": {
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                  "from": "glob-parent@>=2.0.0 <3.0.0"
+                  "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "from": "inherits@>=2.0.1 <3.0.0"
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "is-binary-path": {
                   "version": "1.0.1",
                   "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-                  "from": "is-binary-path@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                   "dependencies": {
                     "binary-extensions": {
                       "version": "1.4.0",
                       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
-                      "from": "binary-extensions@>=1.0.0 <2.0.0"
+                      "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
                     }
                   }
                 },
                 "is-glob": {
                   "version": "2.0.1",
                   "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                  "from": "is-glob@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                   "dependencies": {
                     "is-extglob": {
                       "version": "1.0.0",
                       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                      "from": "is-extglob@>=1.0.0 <2.0.0"
+                      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0"
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 },
                 "readdirp": {
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
-                  "from": "readdirp@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
                   "dependencies": {
                     "minimatch": {
                       "version": "2.0.10",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                      "from": "minimatch@>=2.0.10 <3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.4",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.1",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                              "from": "balanced-match@>=0.4.1 <0.5.0"
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "from": "concat-map@0.0.1"
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
                         }
@@ -959,32 +903,32 @@
                     "readable-stream": {
                       "version": "2.1.2",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
-                      "from": "readable-stream@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "from": "core-util-is@>=1.0.0 <1.1.0"
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "1.0.0",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                          "from": "isarray@>=1.0.0 <1.1.0"
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0"
+                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "from": "string_decoder@>=0.10.0 <0.11.0"
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0"
+                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
                     }
@@ -995,29 +939,29 @@
             "graceful-fs": {
               "version": "4.1.4",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-              "from": "graceful-fs@>=4.1.2 <5.0.0"
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
             }
           }
         },
         "webpack-core": {
           "version": "0.6.8",
           "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
-          "from": "webpack-core@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
           "dependencies": {
             "source-list-map": {
               "version": "0.1.6",
               "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz",
-              "from": "source-list-map@>=0.1.0 <0.2.0"
+              "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz"
             },
             "source-map": {
               "version": "0.4.4",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "from": "source-map@>=0.4.1 <0.5.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "from": "amdefine@>=0.0.4"
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             }
@@ -1028,105 +972,44 @@
     "webpack-dev-middleware": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.6.1.tgz",
-      "from": "webpack-dev-middleware@1.6.1",
+      "from": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.6.1.tgz",
       "dependencies": {
-        "memory-fs": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
-          "from": "memory-fs@>=0.3.0 <0.4.0",
-          "dependencies": {
-            "errno": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-              "from": "errno@>=0.1.3 <0.2.0",
-              "dependencies": {
-                "prr": {
-                  "version": "0.0.0",
-                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-                  "from": "prr@>=0.0.0 <0.1.0"
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
-              "from": "readable-stream@>=2.0.1 <3.0.0",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "from": "inherits@>=2.0.1 <2.1.0"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "from": "isarray@>=1.0.0 <1.1.0"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "from": "string_decoder@>=0.10.0 <0.11.0"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0"
-                }
-              }
-            }
-          }
-        },
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "from": "mime@>=1.3.4 <2.0.0"
-        },
         "range-parser": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
-          "from": "range-parser@>=1.0.3 <2.0.0"
+          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
         }
       }
     },
     "webpack-hot-middleware": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.10.0.tgz",
-      "from": "webpack-hot-middleware@2.10.0",
+      "from": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.10.0.tgz",
       "dependencies": {
         "ansi-html": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.5.tgz",
-          "from": "ansi-html@0.0.5"
+          "from": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.5.tgz"
         },
         "html-entities": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.0.tgz",
-          "from": "html-entities@>=1.2.0 <2.0.0"
+          "from": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.0.tgz"
         },
         "querystring": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-          "from": "querystring@>=0.2.0 <0.3.0"
+          "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "from": "strip-ansi@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "dependencies": {
             "ansi-regex": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-              "from": "ansi-regex@>=2.0.0 <3.0.0"
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             }
           }
         }


### PR DESCRIPTION
I have a project setup where i include .scss files directly from my components with full css-modules support - and then there are third-party libs which comes with final-built .css files and then i collide with the basic "css.modules=true" rule.

So i've extended it - now with this code-change we could define a webpack.json like this:

```
"css": {
    "modules": true,
    "modulesExcludes": [
      "node_modules"
    ]
  },
```

With the "modulesExcludes" option, we can define an array of folders we want to exclude from the css-modules loaders. Whenever this option is found, we generate just another pure css-loader to the loaders-array which will explicitly include those folders. So we will end up by the ability to still handle .scss as css-modules and along them import globally third-party .css's which don't get mangled in any way (and thus just work together with the third-party html-snippet)

When i was already coding, i just added the so missing sourceMap support for the full styles-loaders chain. With another new property in the config:

```
"styles": {
    "sourceMap": true
  },
```

With this option we can globally activate the generation of the "sourceMap" property to all possible involved style-loaders (css/postcss/sass/less)

I really appreciate if we could integrate this change somehow soon - i'm extremely open to discuss and change further so we can really integrate it. The new stack we are building would greatly benefit from this change.

Regards,
Remo