### PR TITLE
fix devServer no working in webpack-dev-server

### DIFF
--- a/packages/webpack/plugin/WebpackCompiler.js
+++ b/packages/webpack/plugin/WebpackCompiler.js
@@ -722,7 +722,7 @@ function compileDevServer(target, entryFile, configFiles, webpackConfig) {
     watchOptions: webpackConfig.watchOptions
   });
 
-  devServerHotMiddleware[target] = Npm.require('webpack-hot-middleware')(compiler);
+  devServerHotMiddleware[target] = Npm.require('webpack-hot-middleware')(compiler,webpackConfig.devServer);
 
   devServerApp.use(devServerMiddleware[target]);
   devServerApp.use(devServerHotMiddleware[target]);


### PR DESCRIPTION
I want to set the `--inline` command to webpack-dev-server, but has not working, then found the problem and fixed the