### PR TITLE
Don't use 'const' in sass/webpack.config.js

### DIFF
--- a/packages/sass/webpack.config.js
+++ b/packages/sass/webpack.config.js
@@ -1,7 +1,7 @@
 var weight = 300;
 
 function dependencies(settings) {
-  const devDependencies = {
+  var devDependencies = {
     'sass-loader': '^3.1.2',
     'node-sass': '^3.4.2'
   };


### PR DESCRIPTION
I experienced a compatibility problem with Internet Explorer <=10 as the production bundle of my project contained a "const" variable declaration.
This is due to this "const" use in `webpack:sass` module.