### PR TITLE
Adds 'postcss' in devDependencies in the webpack:postcss package

### DIFF
--- a/packages/postcss/README.md
+++ b/packages/postcss/README.md
@@ -1,4 +1,4 @@
-# webpack:sass by [The Reactive Stack](https://thereactivestack.com)
+# webpack:postcss by [The Reactive Stack](https://thereactivestack.com)
 Meteor package to integrate PostCSS (.css) import with [Webpack](https://github.com/thereactivestack/meteor-webpack)
 
 ## Warning

--- a/packages/postcss/webpack.config.js
+++ b/packages/postcss/webpack.config.js
@@ -3,6 +3,7 @@ var weight = 210;
 function dependencies(settings) {
   return {
     devDependencies: {
+      'postcss': '^5.1.2',
       'postcss-loader': '^0.8.1'
     }
   };


### PR DESCRIPTION
Found this while having problems with closed issue #250.

Adding this package as a dependency will prevent certain plugins (like 'precss') from throwing errors, if the user does not have the package locally installed.

Changes 'webpack:sass' to 'webpack:postcss' in README.md