### PR TITLE
added map=linked-src option to livescript compiler

### DIFF
--- a/packages/livescript/webpack.config.js
+++ b/packages/livescript/webpack.config.js
@@ -51,7 +51,7 @@ function config(settings, require) {
 
   return {
     loaders: [
-      { test: /\.ls$/, loader: 'babel?' + JSON.stringify(babelSettings) + '!livescript', exclude: /\.meteor|node_modules/ }
+      { test: /\.ls$/, loader: 'babel?' + JSON.stringify(babelSettings) + '!livescript?map=linked-src', exclude: /\.meteor|node_modules/ }
     ],
     extensions: ['.ls'],
   };


### PR DESCRIPTION
Fixing LiveScript bug with Babel as described in https://github.com/appedemic/livescript-loader/issues/10 .