### PR TITLE
Pug (Jade 2.0.0) support

### DIFF
--- a/packages/pug/.versions
+++ b/packages/pug/.versions
@@ -1,0 +1,4 @@
+meteor@1.1.12
+underscore@1.0.6
+webpack:core-config@1.0.1
+webpack:jade@1.0.1

--- a/packages/pug/README.md
+++ b/packages/pug/README.md
@@ -1,0 +1,2 @@
+# webpack:pug by [The Reactive Stack](https://thereactivestack.com)
+Meteor package to integrate Pug import (.pug) with [Webpack](https://atmospherejs.com/webpack/webpack)

--- a/packages/pug/package.js
+++ b/packages/pug/package.js
@@ -1,0 +1,12 @@
+Package.describe({
+    name: 'webpack:pug',
+    version: '1.0.1',
+    summary: 'Integrate Pug import (.pug) with Webpack',
+    git: 'https://github.com/thereactivestack/meteor-webpack.git',
+    documentation: 'README.md'
+});
+
+Package.onUse(function(api) {
+  api.use('webpack:core-config@1.0.1');
+  api.add_files(['webpack.config.js']);
+});

--- a/packages/pug/webpack.config.js
+++ b/packages/pug/webpack.config.js
@@ -1,0 +1,16 @@
+var weight = 500;
+
+function dependencies(settings) {
+  return {
+    devDependencies: {
+      'pug-loader' : '^2.3.0'
+    }
+  };
+}
+
+function config() {
+  return {
+    loaders: [{ test: /\.pug$/, loader: 'pug' }],
+    extensions: ['.pug']
+  };
+}


### PR DESCRIPTION
I created a new webpack:pug package because I needed to support pug instead of jade. See https://github.com/pugjs/pug#rename-from-jade

It is a simple copy of the jade package with "pug" instead of "jade" everywhere and the right pug-loader version (2.3.0). Working fine.